### PR TITLE
Settings: modify AOSP RU SELinux translation

### DIFF
--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -878,7 +878,7 @@
     <string name="baseband_version" msgid="1848990160763524801">"Прошивка модуля связи"</string>
     <string name="kernel_version" msgid="9192574954196167602">"Версия ядра"</string>
     <string name="build_number" msgid="3075795840572241758">"Номер сборки"</string>
-    <string name="selinux_status" msgid="6212165375172061672">"Статус SELinux"</string>
+    <string name="selinux_status" msgid="6212165375172061672">"Режим SELinux"</string>
     <string name="device_info_not_available" msgid="8062521887156825182">"Недоступно"</string>
     <string name="device_status_activity_title" msgid="1411201799384697904">"Общая информация"</string>
     <string name="device_status" msgid="607405385799807324">"Общая информация"</string>
@@ -2154,9 +2154,9 @@
     <string name="backup_pw_set_button_text" msgid="2387480910044648795">"Сохранить пароль"</string>
     <string name="backup_pw_cancel_button_text" msgid="8845630125391744615">"Отмена"</string>
     <string name="additional_system_update_settings_list_item_title" msgid="214987609894661992">"Дополнительные обновления системы"</string>
-    <string name="selinux_status_disabled" msgid="924551035552323327">"Отключено"</string>
-    <string name="selinux_status_permissive" msgid="6004965534713398778">"Только предупреждение"</string>
-    <string name="selinux_status_enforcing" msgid="2252703756208463329">"Блокировка"</string>
+    <string name="selinux_status_disabled" msgid="924551035552323327">"Отключен"</string>
+    <string name="selinux_status_permissive" msgid="6004965534713398778">"Разрешающий"</string>
+    <string name="selinux_status_enforcing" msgid="2252703756208463329">"Принудительный"</string>
     <string name="ssl_ca_cert_warning" msgid="2045866713601984673">"Сеть может отслеживаться"</string>
     <string name="done_button" msgid="1991471253042622230">"Готово"</string>
     <string name="ssl_ca_cert_dialog_title" msgid="5339377665264149395">"Отслеживание сети"</string>


### PR DESCRIPTION
SELinux mode display is not present in AOSP,
but still present in CyanogenMod. Fixitfixit.

Change-Id: I68f8b77be4de1abb0b4186420967fbe1e9980563
