### PR TITLE
USB Settings: Set a sane USB_FUNCTION_DEFAULT

### DIFF
--- a/src/com/android/settings/deviceinfo/UsbSettings.java
+++ b/src/com/android/settings/deviceinfo/UsbSettings.java
@@ -56,7 +56,7 @@ public class UsbSettings extends SettingsPreferenceFragment {
     // may be defined in some sh source file. So here use a hard code for reference,
     // you should modify this value according to device usb init config.
     private static final String USB_FUNCTION_DEFAULT = SystemProperties.get(
-            "ro.sys.usb.default.config", "diag,serial_smd,serial_tty,rmnet_bam,mass_storage");
+            "ro.sys.usb.default.config", "mtp");
 
     private UsbManager mUsbManager;
     private CheckBoxPreference mMtp;


### PR DESCRIPTION
If ro.sys.usb.default.config is not defined by a device, the default
config is absofreakinglutely ridiculous (if only because it contains
mass_storage). Set a sane default of mtp.

Change-Id: If972762760479192cca84fd2a4c9be935386e6f9
