### PR TITLE
Settings: Show SAR on Regulatory Info (from CM11)

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -996,4 +996,11 @@
     <string name="wifi_channel">Channel</string>
     <string name="wifi_mhz">MHz</string>
 
+    <!-- About phone settings screen, setting option dialog title to show regulatory information [CHAR LIMIT=25] -->
+    <string name="regulatory_information_dialog_title">@string/regulatory_information</string>
+
+    <!-- SAR information -->
+    <string name="maximum_head_level">Head: %1$s W/kg</string>
+    <string name="maximum_body_level">Body: %1$s W/kg</string>
+
 </resources>

--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -75,4 +75,12 @@
     <string name="max_cpu_freq_file" translatable="false">/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq</string>
     <string name="min_cpu_freq_file" translatable="false">/sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq</string>
 
+    <!-- SAR Level for a device -->
+    <!-- Must be overlaid by device -->
+    <bool name="config_show_sar_enable" translatable="false">false</bool>
+    <!-- Maximum Specific Absorption Rate for head -->
+    <string name="sar_head_level" translatable="false"></string>
+    <!-- Maximum Specific Absorption Rate for body -->
+    <string name="sar_body_level" translatable="false"></string>
+
 </resources>

--- a/src/com/android/settings/RegulatoryInfoDisplayActivity.java
+++ b/src/com/android/settings/RegulatoryInfoDisplayActivity.java
@@ -28,6 +28,7 @@ import android.view.Gravity;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
+import com.android.settings.deviceinfo.Status;
 
 /**
  * {@link Activity} that displays regulatory information for the "Regulatory information"
@@ -56,7 +57,7 @@ public class RegulatoryInfoDisplayActivity extends Activity implements
         }
 
         AlertDialog.Builder builder = new AlertDialog.Builder(this)
-                .setTitle(R.string.regulatory_information)
+                .setTitle(R.string.regulatory_information_dialog_title)
                 .setOnDismissListener(this);
 
         boolean regulatoryInfoDrawableExists = false;
@@ -73,20 +74,20 @@ public class RegulatoryInfoDisplayActivity extends Activity implements
             }
         }
 
-        CharSequence regulatoryText = resources.getText(R.string.regulatory_info_text);
+        String regulatoryText = Status.getSarValues(getResources());
 
-        if (regulatoryInfoDrawableExists) {
-            View view = getLayoutInflater().inflate(R.layout.regulatory_info, null);
-            ImageView image = (ImageView) view.findViewById(R.id.regulatoryInfo);
-            image.setImageResource(resId);
-            builder.setView(view);
-            builder.show();
-        } else if (regulatoryText.length() > 0) {
+        if (regulatoryText.length() > 0) {
             builder.setMessage(regulatoryText);
             AlertDialog dialog = builder.show();
             // we have to show the dialog first, or the setGravity() call will throw a NPE
             TextView messageText = (TextView) dialog.findViewById(android.R.id.message);
             messageText.setGravity(Gravity.CENTER);
+        } else if (regulatoryInfoDrawableExists) {
+            View view = getLayoutInflater().inflate(R.layout.regulatory_info, null);
+            ImageView image = (ImageView) view.findViewById(R.id.regulatoryInfo);
+            image.setImageResource(resId);
+            builder.setView(view);
+            builder.show();
         } else {
             // neither drawable nor text resource exists, finish activity
             finish();

--- a/src/com/android/settings/deviceinfo/Status.java
+++ b/src/com/android/settings/deviceinfo/Status.java
@@ -102,6 +102,7 @@ public class Status extends PreferenceActivity {
     private static final String KEY_SERIAL_NUMBER = "serial_number";
     private static final String KEY_ICC_ID = "icc_id";
     private static final String KEY_WIMAX_MAC_ADDRESS = "wimax_mac_address";
+
     private static final String[] PHONE_RELATED_ENTRIES = {
         KEY_DATA_STATE,
         KEY_SERVICE_STATE,
@@ -694,4 +695,13 @@ public class Status extends PreferenceActivity {
 
         return Build.SERIAL;
     }
+
+    public static String getSarValues(Resources res) {
+        String headLevel = String.format(res.getString(R.string.maximum_head_level,
+                res.getString(R.string.sar_head_level)));
+        String bodyLevel = String.format(res.getString(R.string.maximum_body_level,
+                res.getString(R.string.sar_body_level)));
+        return headLevel + "\n" + bodyLevel;
+    }
+
 }


### PR DESCRIPTION
This brings these three commits from CM11:

Settings: Create SAR level preference, allow overlay.
Change-Id: I1af616696702f72b8a6276b3b01e940d61735137

Change Regulatory Info Activity to prefer string over image
Change-Id: I9ea5c2bf469af8f654ec4e4bb4f2a8a5738e6a95

Settings: Allow Regulator Information Dialog Title to be overlaid.
Change-Id: I5aead313589f5d5291d20a0388d2d8bc7242b711
